### PR TITLE
Match links support custom routing.

### DIFF
--- a/src/components/match/index.tsx
+++ b/src/components/match/index.tsx
@@ -32,9 +32,11 @@ function Match({
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
         <TopText>{topText}</TopText>
         {(match.href || typeof onMatchClick === 'function') && (
-          <Anchor 
+          <Anchor
             href={match.href}
-            onClick={(event) => onMatchClick?.({ match, topWon, bottomWon,event })}
+            onClick={event =>
+              onMatchClick?.({ match, topWon, bottomWon, event })
+            }
           >
             <TopText>Match Details</TopText>
           </Anchor>

--- a/src/components/match/index.tsx
+++ b/src/components/match/index.tsx
@@ -31,8 +31,11 @@ function Match({
     <Wrapper>
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
         <TopText>{topText}</TopText>
-        {typeof onMatchClick === 'function' && (
-          <Anchor onClick={() => onMatchClick?.({ match, topWon, bottomWon })}>
+        {(match.href || typeof onMatchClick === 'function') && (
+          <Anchor 
+            href={match.href}
+            onClick={(event) => onMatchClick?.({ match, topWon, bottomWon,event })}
+          >
             <TopText>Match Details</TopText>
           </Anchor>
         )}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -18,6 +18,10 @@ export type Participant = {
 export type Match = {
   id: number | string;
 
+  /** Link to this match. While onClick() can be used, providing an href
+      better supports opening a new tab, or copying a link. **/
+  href?: string;
+
   name?: string;
 
   nextMatchId: number | null;
@@ -103,6 +107,7 @@ export type MatchComponentProps = {
     match: Match;
     topWon: boolean;
     bottomWon: boolean;
+    event: React.MouseEvent<HTMLAnchorElement,MouseEvent>;
   }) => void;
 
   onPartyClick: (party: Participant, partyWon: boolean) => void;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -107,7 +107,7 @@ export type MatchComponentProps = {
     match: Match;
     topWon: boolean;
     bottomWon: boolean;
-    event: React.MouseEvent<HTMLAnchorElement,MouseEvent>;
+    event: React.MouseEvent<HTMLAnchorElement, MouseEvent>;
   }) => void;
 
   onPartyClick: (party: Participant, partyWon: boolean) => void;


### PR DESCRIPTION
Closes #31

When using a Single Page Application router such as React Router,
the application code needs access to both the `href` prop and
the `onClick()` prop.

Providing the underlying mouse event to the router
lets it decide when and when not to override the browser's default
behaviour. Providing the `href` prop lets the browser open a link
in a new tab (when applicable) or copy the link.