### PR TITLE
Fix position of child matches

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build-storybook": "build-storybook -o devapp-build",
     "test": "jest --verbose false",
     "lint": "eslint \"src/**/*.js\" \"src/**/*.jsx\"",
-    "format": "eslint --fix \"src/**/*.js\" \"src/**/*.jsx\""
+    "format": "eslint --fix \"src/**/*.js\" \"src/**/*.jsx\"",
+    "prepare": "npm run build"
   },
   "author": "Omar ElGaml",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "build-storybook": "build-storybook -o devapp-build",
     "test": "jest --verbose false",
     "lint": "eslint \"src/**/*.js\" \"src/**/*.jsx\"",
-    "format": "eslint --fix \"src/**/*.js\" \"src/**/*.jsx\"",
-    "prepare": "npm run build"
+    "format": "eslint --fix \"src/**/*.js\" \"src/**/*.jsx\""
   },
   "author": "Omar ElGaml",
   "license": "ISC",
@@ -34,6 +33,7 @@
     "@storybook/addon-links": "^6.5.9",
     "@storybook/addon-storysource": "^6.5.9",
     "@storybook/react": "^6.5.9",
+    "@types/jest": "^29.0.2",
     "@types/styled-components": "^5.1.10",
     "@typescript-eslint/parser": "^4.28.1",
     "babel-eslint": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@storybook/addon-links": "^6.5.9",
     "@storybook/addon-storysource": "^6.5.9",
     "@storybook/react": "^6.5.9",
-    "@types/jest": "^29.0.2",
     "@types/styled-components": "^5.1.10",
     "@typescript-eslint/parser": "^4.28.1",
     "babel-eslint": "^10.1.0",

--- a/src/bracket-single/connectors.tsx
+++ b/src/bracket-single/connectors.tsx
@@ -26,7 +26,7 @@ const Connectors = ({
   });
   const previousBottomPosition = (rowIndex + 1) * 2 - 1;
   const previousTopMatchPosition =
-    bracketSnippet.match &&
+    bracketSnippet.previousTopMatch &&
     calculatePositionOfMatch(previousBottomPosition - 1, columnIndex - 1, {
       canvasPadding,
       rowHeight,
@@ -34,7 +34,7 @@ const Connectors = ({
       offsetY,
     });
   const previousBottomMatchPosition =
-    bracketSnippet.match &&
+    bracketSnippet.previousBottomMatch &&
     calculatePositionOfMatch(previousBottomPosition, columnIndex - 1, {
       canvasPadding,
       rowHeight,

--- a/src/bracket-single/connectors.tsx
+++ b/src/bracket-single/connectors.tsx
@@ -25,26 +25,22 @@ const Connectors = ({
     offsetY,
   });
   const previousBottomPosition = (rowIndex + 1) * 2 - 1;
-  const previousTopMatchPosition = calculatePositionOfMatch(
-    previousBottomPosition - 1,
-    columnIndex - 1,
-    {
+  const previousTopMatchPosition =
+    bracketSnippet.match &&
+    calculatePositionOfMatch(previousBottomPosition - 1, columnIndex - 1, {
       canvasPadding,
       rowHeight,
       columnWidth,
       offsetY,
-    }
-  );
-  const previousBottomMatchPosition = calculatePositionOfMatch(
-    previousBottomPosition,
-    columnIndex - 1,
-    {
+    });
+  const previousBottomMatchPosition =
+    bracketSnippet.match &&
+    calculatePositionOfMatch(previousBottomPosition, columnIndex - 1, {
       canvasPadding,
       rowHeight,
       columnWidth,
       offsetY,
-    }
-  );
+    });
 
   return (
     <Connector

--- a/src/bracket-single/single-elim-bracket.tsx
+++ b/src/bracket-single/single-elim-bracket.tsx
@@ -45,18 +45,22 @@ const SingleEliminationBracket = ({
 
   const generateColumn = matchesColumn => {
     const previousMatchesColumn = matchesColumn.reduce((result, match) => {
+      const previousMatches = matches
+        .filter(m => m.nextMatchId === match.id)
+        .sort((a, b) => sortAlphanumerically(a.name, b.name))
+
+      if (previousMatches.length === 1) previousMatches.unshift(null);
+      if (previousMatches.length === 2) previousMatches.unshift(null, null);
       return [
         ...result,
-        ...matches
-          .filter(m => m.nextMatchId === match.id)
-          .sort((a, b) => sortAlphanumerically(a.name, b.name)),
+        ...previousMatches,
       ];
     }, []);
 
-    if (previousMatchesColumn.length > 0) {
+    if (previousMatchesColumn.length > 0 && previousMatchesColumn.every(Boolean)) {
       return [...generateColumn(previousMatchesColumn), previousMatchesColumn];
     }
-    return [previousMatchesColumn];
+    return [previousMatchesColumn.some(Boolean)? previousMatchesColumn : []];
   };
   const generate2DBracketArray = final => {
     return final
@@ -123,7 +127,7 @@ const SingleEliminationBracket = ({
                           canvasPadding={canvasPadding}
                           width={width}
                           numOfRounds={columns.length}
-                          tournamentRoundText={match.tournamentRoundText}
+                          tournamentRoundText={match?.tournamentRoundText}
                           columnIndex={columnIndex}
                         />
                       )}
@@ -143,7 +147,7 @@ const SingleEliminationBracket = ({
                           }}
                         />
                       )}
-                      <g>
+                      {match && <g>
                         <MatchWrapper
                           x={x}
                           y={
@@ -164,7 +168,7 @@ const SingleEliminationBracket = ({
                           style={style}
                           matchComponent={matchComponent}
                         />
-                      </g>
+                      </g>}
                     </>
                   );
                 })

--- a/src/bracket-single/single-elim-bracket.tsx
+++ b/src/bracket-single/single-elim-bracket.tsx
@@ -50,7 +50,7 @@ const SingleEliminationBracket = ({
         .sort((a, b) => sortAlphanumerically(a.name, b.name))
 
       if (previousMatches.length === 1) previousMatches.unshift(null);
-      if (previousMatches.length === 2) previousMatches.unshift(null, null);
+      if (previousMatches.length === 0) previousMatches.unshift(null, null);
       return [
         ...result,
         ...previousMatches,


### PR DESCRIPTION
Hey, thank you for your work!
I want to improve it a bit. The point is when the parent element has only one child (like on the screenshot) column doesn't care about it and shifts it to the top. So I place the empty value on the index when the match shouldn't be. It's just my implementation, it works, but you can change it however you want. I just wanted to present the issue and idea of how to solve it.

![Screenshot 2022-12-01 at 17 18 40](https://user-images.githubusercontent.com/32685792/205090222-88af4513-eb52-44b0-a62a-40db99f5edf9.png)

