### PR TITLE
Update webpack config for both browser and Node.js (incl. Next.js)

### DIFF
--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -54,6 +54,7 @@ module.exports = {
     filename: 'bundle.js',
     library: '@g-loot/react-tournament-brackets',
     libraryTarget: 'umd',
+    globalObject: 'this',
   },
   externals: {
     'styled-components': {


### PR DESCRIPTION
This will resolve the #34, #51 and potentially many others.
https://webpack.js.org/configuration/output/#outputglobalobject

The dynamic imports "workaround" in #34 prevents our `npm run build` and thus blocks the whole dev pipeline.

May I also suggest to review the current versions as some of them are 2+ years old.

Meanwhile (if anyone else is suffering from the same issue): in your text editor, open the `node_modules/@g-loot/react-tournament-brackets/dist/bundle.js` and add just one line in the very beginning:
```
const window = global.window;
```

many thanks
