### PR TITLE
Set SVG Height based on max of column lengths.

### DIFF
--- a/src/bracket-double/double-elim-bracket.tsx
+++ b/src/bracket-double/double-elim-bracket.tsx
@@ -127,7 +127,7 @@ const DoubleEliminationBracket = ({
   const totalNumOfRounds =
     lowerColumns.length + 1 + (hasMultipleFinals && finalsArray.length - 1);
   const upperBracketDimensions = calculateSVGDimensions(
-    upperColumns[0].length,
+    Math.max(...upperColumns.map(column => column.length)),
     upperColumns.length,
     rowHeight,
     columnWidth,
@@ -136,7 +136,7 @@ const DoubleEliminationBracket = ({
     currentRound
   );
   const lowerBracketDimensions = calculateSVGDimensions(
-    lowerColumns[0].length,
+    Math.max(...lowerColumns.map(column => column.length)),
     lowerColumns.length,
     rowHeight,
     columnWidth,
@@ -145,7 +145,7 @@ const DoubleEliminationBracket = ({
     currentRound
   );
   const fullBracketDimensions = calculateSVGDimensions(
-    lowerColumns[0].length,
+    Math.max(...lowerColumns.map(column => column.length).concat(upperColumns.map(rows => rows.length))),
     totalNumOfRounds,
     rowHeight,
     columnWidth,

--- a/src/bracket-single/single-elim-bracket.tsx
+++ b/src/bracket-single/single-elim-bracket.tsx
@@ -75,7 +75,7 @@ const SingleEliminationBracket = ({
   // ]
 
   const { gameWidth, gameHeight, startPosition } = calculateSVGDimensions(
-    columns[0].length,
+    Math.max(...columns.map(column => column.length)),
     columns.length,
     rowHeight,
     columnWidth,


### PR DESCRIPTION
Currently, the height of the SVG is set based on the length of the first column. This works when the first round of the bracket is completely full. However, if the bracket is sparse (i.e. bye rounds are not shown), then it's possible for the first column to have fewer matches (and therefore be shorter) than later columns.

To fix this, I have updated the calls to `calculateSVGDimensions`. Before, the numOfRows param was always set to the length of columns[0]. Now, it is set to the maximum length of all columns.